### PR TITLE
Fix dependency installation command for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ apt-get install qemu grub-pc-bin xorriso mtools
 
 If you are using `pacman` as your package manager (`ArchLinux`, `Manjaro` etc.), you can use this command:
 ```bash
-pacman -Sy qemu grub libisoburn mtools
+pacman -Syu dialog qemu grub libisoburn mtools
 ```
 
 If you are using `portage` as your package manager (`Gentoo`), you can use this command instead:


### PR DESCRIPTION
You should never update the package list (`-y`) and install a package without upgrading (`-u`).
See [the official wiki page about Pacman](https://wiki.archlinux.org/index.php/Pacman#Installing_packages).
`dialog` is also not installed by default on Arch Linux.

This isn't the largest of pull requests, but it's better to fix documentation issues as soon as possible.