### PR TITLE
Fixed typo in kernel where handles where named handlers

### DIFF
--- a/include/chaosdef.h
+++ b/include/chaosdef.h
@@ -58,9 +58,9 @@ typedef uint32_t		uint32;
 typedef uint64_t		uint64;
 typedef uintptr_t		uintptr;
 
-/* ChaOS Object's Handler */
-typedef uint			handler_t;
-typedef handler_t		file_handler_t;
+/* ChaOS Object's Handle */
+typedef uint			handle_t;
+typedef handle_t		file_handle_t;
 
 /* Print a message and halt the computer. */
 void				panic(char const *fmt, ...) __noreturn;

--- a/include/chaoserr.h
+++ b/include/chaoserr.h
@@ -34,7 +34,7 @@ enum				status
 	/* Parameters errors */
 	ERR_INVALID_ARGS,		/* Invaid arguments */
 	ERR_OUT_OF_RANGE,		/* One of the argument was outside the valid range for this operation */
-	ERR_BAD_HANDLER,			/* The operation is missing a handler or callback to call */
+	ERR_BAD_HANDLER,		/* The operation is missing a handler or callback to call */
 
 	/* State errors */
 	ERR_BAD_STATE,			/* Operation couldn't complete because it's current state wouldn't allow the operation to complete (eg: pre-conditions not satisfied) */

--- a/include/chaoserr.h
+++ b/include/chaoserr.h
@@ -34,7 +34,7 @@ enum				status
 	/* Parameters errors */
 	ERR_INVALID_ARGS,		/* Invaid arguments */
 	ERR_OUT_OF_RANGE,		/* One of the argument was outside the valid range for this operation */
-	ERR_BAD_HANDLE,			/* The operation is missing a handler or callback to call */
+	ERR_BAD_HANDLER,			/* The operation is missing a handler or callback to call */
 
 	/* State errors */
 	ERR_BAD_STATE,			/* Operation couldn't complete because it's current state wouldn't allow the operation to complete (eg: pre-conditions not satisfied) */

--- a/include/kernel/fs.h
+++ b/include/kernel/fs.h
@@ -23,7 +23,7 @@
 
 struct bdev;
 struct dirent;
-struct filehandler;
+struct filehandle;
 
 /*
 ** Api that a filesystem must (at least partialy) implement
@@ -32,13 +32,13 @@ struct fs_api
 {
 	status_t (*mount)(struct bdev *, void **);
 	status_t (*unmount)(void *);
-	status_t (*open)(void *, char const *, struct filehandler *);
-	status_t (*close)(void *, struct filehandler *);
+	status_t (*open)(void *, char const *, struct filehandle *);
+	status_t (*close)(void *, struct filehandle *);
 	status_t (*readdir)(void *, void *, struct dirent *);
 };
 
 /*
-** Handler on a mounted filesystem
+** Handle on a mounted filesystem
 */
 struct fs_mount
 {
@@ -52,10 +52,10 @@ struct fs_mount
 };
 
 /*
-** Handler on an opened file
+** Handle on an opened file
 ** Used for reading, writing etc.
 */
-struct filehandler
+struct filehandle
 {
 	struct fs_mount *mount;
 	uint type;
@@ -74,9 +74,9 @@ struct dirent
 /* Generic fs functions */
 status_t		fs_mount(char const *p, char const *fs, char const *dev);
 status_t		fs_unmount(char const *path);
-status_t		fs_open(char const *path, struct filehandler **handler);
-status_t		fs_close(struct filehandler *filehandler);
-status_t		fs_readdir(struct filehandler *handler, struct dirent *dirent);
+status_t		fs_open(char const *path, struct filehandle **handle);
+status_t		fs_close(struct filehandle *filehandle);
+status_t		fs_readdir(struct filehandle *handle, struct dirent *dirent);
 
 struct fs_hook
 {

--- a/include/kernel/syscall.h
+++ b/include/kernel/syscall.h
@@ -29,6 +29,6 @@ enum syscall_id
 status_t	sys_clone(void *main);
 void		sys_exit(uchar status);
 status_t	sys_exec(char const *path);
-int		sys_write(file_handler_t handler, char const *buff, size_t s);
+int		sys_write(file_handle_t handle, char const *buff, size_t s);
 
 #endif /* !_KERNEL_SYSCALL_H_ */

--- a/kernel/fs.c
+++ b/kernel/fs.c
@@ -375,9 +375,9 @@ fs_unmount(char const *path)
 ** Opens the file at the given path
 */
 status_t
-fs_open(char const *path, struct filehandler **handler)
+fs_open(char const *path, struct filehandle **handle)
 {
-	struct filehandler *fh;
+	struct filehandle *fh;
 	struct fs_mount *mount;
 	char *tmp;
 	char const *newpath;
@@ -395,7 +395,7 @@ fs_open(char const *path, struct filehandler **handler)
 		goto err;
 	}
 
-	if (!(fh = kalloc(sizeof(struct filehandler)))) {
+	if (!(fh = kalloc(sizeof(struct filehandle)))) {
 		err = ERR_NO_MEMORY;
 		goto err;
 	}
@@ -406,7 +406,7 @@ fs_open(char const *path, struct filehandler **handler)
 	if (err) {
 		goto err;
 	}
-	*handler = fh;
+	*handle = fh;
 	return (OK);
 
 err:
@@ -419,21 +419,21 @@ err:
 }
 
 /*
-** Closes the given handler, and kfrees it.
+** Closes the given handle, and kfrees it.
 */
 status_t
-fs_close(struct filehandler *handler)
+fs_close(struct filehandle *handle)
 {
 	status_t err;
 	struct fs_mount *mount;
 
-	mount = handler->mount;
-	err = mount->api->close(mount->fs_data, handler);
+	mount = handle->mount;
+	err = mount->api->close(mount->fs_data, handle);
 	if (err) {
 		return (err);
 	}
 	put_mount(mount);
-	kfree(handler);
+	kfree(handle);
 	return (OK);
 }
 
@@ -441,15 +441,15 @@ fs_close(struct filehandler *handler)
 ** Reads an entry in the given directory, and stores it in 'dirent'.
 */
 status_t
-fs_readdir(struct filehandler *handler, struct dirent *dirent)
+fs_readdir(struct filehandle *handle, struct dirent *dirent)
 {
 	struct fs_mount *mount;
 
-	if (!(handler->type & FS_DIRECTORY)) {
+	if (!(handle->type & FS_DIRECTORY)) {
 		return (ERR_NOT_DIRECTORY);
 	}
-	mount = handler->mount;
-	return (mount->api->readdir(mount->fs_data, handler->file_data, dirent));
+	mount = handle->mount;
+	return (mount->api->readdir(mount->fs_data, handle->file_data, dirent));
 }
 
 static void

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -58,7 +58,7 @@ sys_exec(char const *path)
 ** Writes the given buffer to the given file.
 */
 int
-sys_write(file_handler_t handler __unused /* TODO */, char const *buff, size_t s)
+sys_write(file_handle_t handle __unused /* TODO */, char const *buff, size_t s)
 {
 	/* TODO FIXME We should ensure 'buff' points to valid userspace memory. */
 	return (vga_putsn(buff, s));

--- a/lib/fs/dumbfs.c
+++ b/lib/fs/dumbfs.c
@@ -44,7 +44,7 @@ static status_t
 dumbfs_open(
 	void *fscookie __unused /* TODO */,
 	char const *path __unused /* TODO */,
-	struct filehandler *handler __unused /* TODO */
+	struct filehandle *handle __unused /* TODO */
 )
 {
 	/* TODO */
@@ -54,7 +54,7 @@ dumbfs_open(
 static status_t
 dumbfs_close(
 	void *fscookie __unused /* TODO */,
-	struct filehandler *handler __unused /* TODO */
+	struct filehandle *handle __unused /* TODO */
 )
 {
 	return (OK);

--- a/userspace/ulib.h
+++ b/userspace/ulib.h
@@ -57,9 +57,9 @@ exec(char const *path)
 
 __unused
 static size_t
-write(file_handler_t handler, char const *str, size_t n)
+write(file_handle_t handle, char const *str, size_t n)
 {
-	return (syscall(SYSCALL_WRITE, handler, (uintptr)str, n, 0));
+	return (syscall(SYSCALL_WRITE, handle, (uintptr)str, n, 0));
 }
 
 /* C Library */


### PR DESCRIPTION
Careful attention was given not to rename genuine handlers (typically those for kernel interrupts).
This change is purely about nomenclature. It  should not affect the kernels behaviour.